### PR TITLE
Add the shell script and the dockerfile to build the gdb 9.2 with the core analyzer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+bin
+test
+Windbg_ext

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# ==============================================================================================
+# FILENAME	:	Dockerfile
+# AUTHOR	:	Celthi
+# CREATION	:	2021-12-14
+# Dockerfile to build enhanced gdb with core analyzer
+# ==============================================================================================
+
+
+
+FROM ubuntu:18.04
+RUN apt update \
+    && apt install -y texinfo \
+    && apt install -y build-essential \
+    && apt install -y wget
+
+WORKDIR /usr/src/app
+COPY . .
+
+RUN ./build_gdb.sh
+ENTRYPOINT ["gdb"]
+

--- a/build_gdb.sh
+++ b/build_gdb.sh
@@ -1,0 +1,42 @@
+# ==============================================================================================
+# FILENAME	:	build_gdb.sh
+# AUTHOR	:	Celthi
+# CREATION	:	2021-12-14
+# Script to build the custom gdb with core analyzer.
+# This script will the do the following steps
+# 1. check the gdb version
+# 2. download the gdb 9.2 from gnu.org
+# 3. copy the core analyzer code to the gdb
+# 4. build the gdb
+# ==============================================================================================
+
+PROJECT_FOLDER=$(pwd)
+echo "Current project folder is $PROJECT_FOLDER"
+GDB_VERSION=$(gdb --version | grep "GNU gdb" | awk '{print $8}')
+VERSION_NUM="${GDB_VERSION:0:5}"
+echo $VERSION_NUM
+if [[ "$VERSION_NUM" < "9.2.0" ]]
+then
+    echo "installing gdb 9.2..."
+    temp_folder='gdb_download'
+    mkdir -p /tmp/$temp_folder
+    cd /tmp/$temp_folder
+    gdb_to_install='gdb-9.2'
+    tar_gdb="${gdb_to_install}.tar.gz"
+    if [ ! -f $tar_gdb ]
+    then
+        wget http://ftp.gnu.org/gnu/gdb/$tar_gdb
+    fi
+    if [ ! -d $tar_gdb ]
+    then
+        tar -xf $tar_gdb
+    fi
+    cd $gdb_to_install
+    cp -rLv $PROJECT_FOLDER/gdbplus/gdb-9.2/gdb . 
+    mkdir build
+    cd build
+    PWD=$(pwd)
+
+    $PWD/../configure -disable-binutils --disable-ld --disable-gold --disable-gas --disable-sim --disable-gprof CXXFLAGS='-g' CFLAGS='-g' --prefix=/usr
+    make && make install #&& rm -rf /tmp/$temp_folder
+fi

--- a/build_gdb.sh
+++ b/build_gdb.sh
@@ -4,7 +4,7 @@
 # CREATION	:	2021-12-14
 # Script to build the custom gdb with core analyzer.
 # This script will the do the following steps
-# 1. check the gdb version
+# 1. Create working directory
 # 2. download the gdb 9.2 from gnu.org
 # 3. copy the core analyzer code to the gdb
 # 4. build the gdb
@@ -12,31 +12,26 @@
 
 PROJECT_FOLDER=$(pwd)
 echo "Current project folder is $PROJECT_FOLDER"
-GDB_VERSION=$(gdb --version | grep "GNU gdb" | awk '{print $8}')
-VERSION_NUM="${GDB_VERSION:0:5}"
-echo $VERSION_NUM
-if [[ "$VERSION_NUM" < "9.2.0" ]]
+echo "installing gdb 9.2..."
+temp_folder='gdb_download'
+mkdir -p /tmp/$temp_folder
+cd /tmp/$temp_folder
+gdb_to_install='gdb-9.2'
+tar_gdb="${gdb_to_install}.tar.gz"
+if [ ! -f $tar_gdb ]
 then
-    echo "installing gdb 9.2..."
-    temp_folder='gdb_download'
-    mkdir -p /tmp/$temp_folder
-    cd /tmp/$temp_folder
-    gdb_to_install='gdb-9.2'
-    tar_gdb="${gdb_to_install}.tar.gz"
-    if [ ! -f $tar_gdb ]
-    then
-        wget http://ftp.gnu.org/gnu/gdb/$tar_gdb
-    fi
-    if [ ! -d $tar_gdb ]
-    then
-        tar -xf $tar_gdb
-    fi
-    cd $gdb_to_install
-    cp -rLv $PROJECT_FOLDER/gdbplus/gdb-9.2/gdb . 
-    mkdir build
-    cd build
-    PWD=$(pwd)
-
-    $PWD/../configure -disable-binutils --disable-ld --disable-gold --disable-gas --disable-sim --disable-gprof CXXFLAGS='-g' CFLAGS='-g' --prefix=/usr
-    make && make install #&& rm -rf /tmp/$temp_folder
+    wget http://ftp.gnu.org/gnu/gdb/$tar_gdb
 fi
+if [ ! -d $tar_gdb ]
+then
+    tar -xf $tar_gdb
+fi
+cd $gdb_to_install
+cp -rLv $PROJECT_FOLDER/gdbplus/gdb-9.2/gdb . 
+mkdir build
+cd build
+PWD=$(pwd)
+# if you prefer the gdb with debug symbol use commented line to build
+# $PWD/../configure -disable-binutils --disable-ld --disable-gold --disable-gas --disable-sim --disable-gprof CXXFLAGS='-g' CFLAGS='-g' --prefix=/usr
+$PWD/../configure
+make && make install && rm -rf /tmp/$temp_folder


### PR DESCRIPTION
Hi Michael,
I add the shell script and dockerfile to build the gdb 9.2 with the core analyzer.
With the `dockerfile` and the script, it is easier to build.