### PR TITLE
Support multi heap managers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
 # [Optional] Uncomment this section to install additional packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y texinfo \
+    && apt install -y libgmp-dev \
     && apt install -y build-essential \
     && apt install -y wget \
     && apt install -y python-dev \

--- a/gdbplus/gdb-12.1/gdb/Makefile.in
+++ b/gdbplus/gdb-12.1/gdb/Makefile.in
@@ -1092,6 +1092,7 @@ COMMON_SFILES = \
 	go-typeprint.c \
 	go-valprint.c \
 	heap.c \
+	heap_ptmalloc_2_27.c \
 	heap_ptmalloc_2_31.c \
 	heap_ptmalloc_2_35.c \
 	heapcmd.c \

--- a/gdbplus/gdb-12.1/gdb/Makefile.in
+++ b/gdbplus/gdb-12.1/gdb/Makefile.in
@@ -1092,7 +1092,7 @@ COMMON_SFILES = \
 	go-typeprint.c \
 	go-valprint.c \
 	heap.c \
-	heap_ptmalloc.c \
+	heap_ptmalloc_2_31.c \
 	heap_ptmalloc_2_35.c \
 	heapcmd.c \
 	i386-decode.c \

--- a/gdbplus/gdb-12.1/gdb/Makefile.in
+++ b/gdbplus/gdb-12.1/gdb/Makefile.in
@@ -1092,6 +1092,7 @@ COMMON_SFILES = \
 	go-typeprint.c \
 	go-valprint.c \
 	heap.c \
+	heap_ptmalloc.c \
 	heap_ptmalloc_2_35.c \
 	heapcmd.c \
 	i386-decode.c \

--- a/gdbplus/gdb-12.1/gdb/gdb_dep.c
+++ b/gdbplus/gdb-12.1/gdb/gdb_dep.c
@@ -4,7 +4,6 @@
  *  Created on: Dec 13, 2011
  *      Author: myan
  */
-#include <gnu/libc-version.h>
 #include "segment.h"
 #include "heap.h"
 #include "search.h"
@@ -64,53 +63,19 @@ const char *ca_field_name(struct type *type, int i)
     return type->field(i).name();
 }
 
-/*
- * Get the glibc version of the debugee
- */
-bool ca_glibc_version(int *major, int *minor)
+bool get_gv_value(const char *varname, char *buf, size_t bufsz)
 {
-	if (!major || !minor)
-		return false;
-
-	const size_t bufsz = 64;
-	char buf[bufsz];
 	struct symbol *sym;
 
-	memset(buf, 0, bufsz);
-	sym = lookup_static_symbol("__libc_version", VAR_DOMAIN).symbol;
-	if (sym == NULL) {
-		CA_PRINT("Cannot get the \"__libc_version\" from the debugee, read it from the host machine. This might not be accurate.\n");
-		const char* version = gnu_get_libc_version();
-		int len = strlen(version);
-		if (len >= bufsz)
-			return false;
-
-		strncpy(buf, version, len+1);
-
-	} else {
+	sym = lookup_static_symbol(varname, VAR_DOMAIN).symbol;
+	if (sym) {
 		struct value *val = value_of_variable(sym, 0);
-		gdb::array_view<const gdb_byte> content = value_contents(val);
-		memcpy(buf, content.data(), TYPE_LENGTH(value_type(val)));
-	}
-
-	int len = strlen(buf);
-	for (int i=0; i<len; i++)
-	{
-		if (buf[i] == '.')
-		{
-			buf[i] = '\0';
-			*major = atoi(&buf[0]);
-			*minor = atoi(&buf[i+1]);
-			if (*major != 2)
-			{
-				CA_PRINT("This version of glibc %d.%d is not tested, please contact the owner\n",
-						*major, *minor);
-				return false;
-			}
+		if (bufsz >= TYPE_LENGTH(value_type(val))) {
+			gdb::array_view<const gdb_byte> content = value_contents(val);
+			memcpy(buf, content.data(), TYPE_LENGTH(value_type(val)));
 			return true;
 		}
 	}
-
 	return false;
 }
 

--- a/gdbplus/gdb-12.1/gdb/gdb_dep.c
+++ b/gdbplus/gdb-12.1/gdb/gdb_dep.c
@@ -4,6 +4,7 @@
  *  Created on: Dec 13, 2011
  *      Author: myan
  */
+#include <gnu/libc-version.h>
 #include "segment.h"
 #include "heap.h"
 #include "search.h"
@@ -46,6 +47,71 @@ inferior_memory_read (address_t addr, void* buffer, size_t sz)
 		return true;
 	else
 		return false;
+}
+
+void ca_switch_to_thread(struct thread_info *info)
+{
+    switch_to_thread (info);
+}
+
+int ca_num_fields(struct type *type)
+{
+    return type->num_fields();
+}
+
+const char *ca_field_name(struct type *type, int i)
+{
+    return type->field(i).name();
+}
+
+/*
+ * Get the glibc version of the debugee
+ */
+bool ca_glibc_version(int *major, int *minor)
+{
+	if (!major || !minor)
+		return false;
+
+	const size_t bufsz = 64;
+	char buf[bufsz];
+	struct symbol *sym;
+
+	memset(buf, 0, bufsz);
+	sym = lookup_static_symbol("__libc_version", VAR_DOMAIN).symbol;
+	if (sym == NULL) {
+		CA_PRINT("Cannot get the \"__libc_version\" from the debugee, read it from the host machine. This might not be accurate.\n");
+		const char* version = gnu_get_libc_version();
+		int len = strlen(version);
+		if (len >= bufsz)
+			return false;
+
+		strncpy(buf, version, len+1);
+
+	} else {
+		struct value *val = value_of_variable(sym, 0);
+		gdb::array_view<const gdb_byte> content = value_contents(val);
+		memcpy(buf, content.data(), TYPE_LENGTH(value_type(val)));
+	}
+
+	int len = strlen(buf);
+	for (int i=0; i<len; i++)
+	{
+		if (buf[i] == '.')
+		{
+			buf[i] = '\0';
+			*major = atoi(&buf[0]);
+			*minor = atoi(&buf[i+1]);
+			if (*major != 2)
+			{
+				CA_PRINT("This version of glibc %d.%d is not tested, please contact the owner\n",
+						*major, *minor);
+				return false;
+			}
+			return true;
+		}
+	}
+
+	return false;
 }
 
 static int

--- a/gdbplus/gdb-12.1/gdb/gdb_dep.c
+++ b/gdbplus/gdb-12.1/gdb/gdb_dep.c
@@ -379,8 +379,6 @@ build_segments(void)
 bool
 update_memory_segments_and_heaps(void)
 {
-	bool rc = true;
-
 	/* reset internal quit flag */
 	g_quit = false;
 
@@ -422,9 +420,7 @@ update_memory_segments_and_heaps(void)
 		return false;
 	}
 	/* Probe for heap segments */
-	CA_HEAP->init_heap();
-
-	return rc;
+    return init_heap_managers();
 }
 
 int

--- a/gdbplus/gdb-12.1/gdb/heap_ptmalloc.c
+++ b/gdbplus/gdb-12.1/gdb/heap_ptmalloc.c
@@ -1,1 +1,0 @@
-../../../src/heap_ptmalloc.cpp

--- a/gdbplus/gdb-12.1/gdb/heap_ptmalloc_2_27.c
+++ b/gdbplus/gdb-12.1/gdb/heap_ptmalloc_2_27.c
@@ -1,0 +1,1 @@
+../../../src/heap_ptmalloc_2_27.cpp

--- a/gdbplus/gdb-12.1/gdb/heap_ptmalloc_2_31.c
+++ b/gdbplus/gdb-12.1/gdb/heap_ptmalloc_2_31.c
@@ -1,0 +1,1 @@
+../../../src/heap_ptmalloc_2_31.cpp

--- a/gdbplus/gdb-12.1/gdb/heapcmd.c
+++ b/gdbplus/gdb-12.1/gdb/heapcmd.c
@@ -265,6 +265,10 @@ display_help_command (const char *arg, int from_tty)
 static void
 switch_heap_command(const char *arg, int from_tty)
 {
+	/* Ensure heap manager is initialized */
+	if (!update_memory_segments_and_heaps())
+		return;
+
 	if (!arg) {
 		auto supported_heaps = get_supported_heaps();
 		CA_PRINT("Please provide the heap manager name, currently supported heap managers: %s.\n", supported_heaps.c_str());
@@ -292,7 +296,6 @@ void _initialize_heapcmd ();
 void
 _initialize_heapcmd ()
 {
-	register_heap_managers(); // todo: find a better place to register heaps. maybe update_memory_segments_and_heaps is better than here.
 	add_cmd("ref", class_info, ref_command, _("Search for references to a given object.\nref <addr_exp>\nref [/thread or /t] <addr_exp> <size> [level]"), &cmdlist);
 	add_cmd("obj", class_info, obj_command, _("Search for object and reference to object of the same type as the input expression\nobj <type|variable>"), &cmdlist);
 	add_cmd("shrobj", class_info, shrobj_command, _("Find objects that currently referenced from multiple threads\nshrobj [tid0] [tid1] [...]"), &cmdlist);

--- a/gdbplus/gdb-9.2/gdb/Makefile.in
+++ b/gdbplus/gdb-9.2/gdb/Makefile.in
@@ -1063,6 +1063,7 @@ COMMON_SFILES = \
 	go-typeprint.c \
 	go-valprint.c \
 	heap.c \
+	heap_ptmalloc_2_27.c \
 	heap_ptmalloc_2_31.c \
 	heap_ptmalloc_2_35.c \
 	heap_tcmalloc.c \

--- a/gdbplus/gdb-9.2/gdb/Makefile.in
+++ b/gdbplus/gdb-9.2/gdb/Makefile.in
@@ -1063,7 +1063,8 @@ COMMON_SFILES = \
 	go-typeprint.c \
 	go-valprint.c \
 	heap.c \
-	heap_ptmalloc.c \
+	heap_ptmalloc_2_31.c \
+	heap_ptmalloc_2_35.c \
 	heap_tcmalloc.c \
 	heapcmd.c \
 	i386-decode.c \

--- a/gdbplus/gdb-9.2/gdb/gdb_dep.c
+++ b/gdbplus/gdb-9.2/gdb/gdb_dep.c
@@ -4,7 +4,6 @@
  *  Created on: Dec 13, 2011
  *      Author: myan
  */
-#include <gnu/libc-version.h>
 #include "segment.h"
 #include "heap.h"
 #include "search.h"
@@ -64,53 +63,19 @@ const char *ca_field_name(struct type *type, int i)
     return TYPE_FIELD_NAME (type, i);
 }
 
-/*
- * Get the glibc version of the debugee
- */
-bool ca_glibc_version(int *major, int *minor)
+bool get_gv_value(const char *varname, char *buf, size_t bufsz)
 {
-	if (!major || !minor)
-		return false;
-
-	const size_t bufsz = 64;
-	char buf[bufsz];
 	struct symbol *sym;
 
-	memset(buf, 0, bufsz);
-	sym = lookup_static_symbol("__libc_version", VAR_DOMAIN).symbol;
-	if (sym == NULL) {
-		CA_PRINT("Cannot get the \"__libc_version\" from the debugee, read it from the host machine. This might not be accurate.\n");
-		const char* version = gnu_get_libc_version();
-		int len = strlen(version);
-		if (len >= bufsz)
-			return false;
-
-		strncpy(buf, version, len+1);
-
-	} else {
+	sym = lookup_static_symbol(varname, VAR_DOMAIN).symbol;
+	if (sym) {
 		struct value *val = value_of_variable(sym, 0);
-		const gdb_byte *content = value_contents(val);
-		memcpy(buf, content, TYPE_LENGTH(value_type(val)));
-	}
-
-	int len = strlen(buf);
-	for (int i=0; i<len; i++)
-	{
-		if (buf[i] == '.')
-		{
-			buf[i] = '\0';
-			*major = atoi(&buf[0]);
-			*minor = atoi(&buf[i+1]);
-			if (*major != 2)
-			{
-				CA_PRINT("This version of glibc %d.%d is not tested, please contact the owner\n",
-						*major, *minor);
-				return false;
-			}
+		if (bufsz >= TYPE_LENGTH(value_type(val))) {
+			const gdb_byte *content = value_contents(val);
+			memcpy(buf, content, TYPE_LENGTH(value_type(val)));
 			return true;
 		}
 	}
-
 	return false;
 }
 

--- a/gdbplus/gdb-9.2/gdb/gdb_dep.c
+++ b/gdbplus/gdb-9.2/gdb/gdb_dep.c
@@ -382,8 +382,6 @@ build_segments(void)
 bool
 update_memory_segments_and_heaps(void)
 {
-	bool rc = true;
-
 	/* reset internal quit flag */
 	g_quit = false;
 
@@ -425,9 +423,7 @@ update_memory_segments_and_heaps(void)
 		return false;
 	}
 	/* Probe for heap segments */
-	CA_HEAP->init_heap();
-
-	return rc;
+    return init_heap_managers();
 }
 
 int

--- a/gdbplus/gdb-9.2/gdb/heap_ptmalloc.c
+++ b/gdbplus/gdb-9.2/gdb/heap_ptmalloc.c
@@ -1,1 +1,0 @@
-../../../src/heap_ptmalloc.cpp

--- a/gdbplus/gdb-9.2/gdb/heap_ptmalloc_2_27.c
+++ b/gdbplus/gdb-9.2/gdb/heap_ptmalloc_2_27.c
@@ -1,0 +1,1 @@
+../../../src/heap_ptmalloc_2_27.cpp

--- a/gdbplus/gdb-9.2/gdb/heap_ptmalloc_2_31.c
+++ b/gdbplus/gdb-9.2/gdb/heap_ptmalloc_2_31.c
@@ -1,0 +1,1 @@
+../../../src/heap_ptmalloc_2_31.cpp

--- a/gdbplus/gdb-9.2/gdb/heap_ptmalloc_2_35.c
+++ b/gdbplus/gdb-9.2/gdb/heap_ptmalloc_2_35.c
@@ -1,0 +1,1 @@
+../../../src/heap_ptmalloc_2_35.cpp

--- a/gdbplus/gdb-9.2/gdb/heapcmd.c
+++ b/gdbplus/gdb-9.2/gdb/heapcmd.c
@@ -289,7 +289,6 @@ switch_heap_command(const char *arg, int from_tty)
 void
 _initialize_heapcmd (void)
 {
-	register_heap_managers(); // todo: find a better place to register heaps. maybe update_memory_segments_and_heaps is better than here.
 	add_cmd("ref", class_info, ref_command, _("Search for references to a given object.\nref <addr_exp>\nref [/thread or /t] <addr_exp> <size> [level]"), &cmdlist);
 	add_cmd("obj", class_info, obj_command, _("Search for object and reference to object of the same type as the input expression\nobj <type|variable>"), &cmdlist);
 	add_cmd("shrobj", class_info, shrobj_command, _("Find objects that currently referenced from multiple threads\nshrobj [tid0] [tid1] [...]"), &cmdlist);

--- a/src/core_elf.cpp
+++ b/src/core_elf.cpp
@@ -793,7 +793,6 @@ static bool InitLinkMap_32(MmapFile& irExec, MmapFile& irCore)
 //////////////////////////////////////////////////////////////
 bool InitCoreAnalyzer(MmapFile& irExec, MmapFile& irCore)
 {
-	register_heap_managers();
 	int ptr_bit = g_ptr_bit;
 	bool rc;
 	if (ptr_bit == 64)
@@ -812,7 +811,7 @@ bool InitCoreAnalyzer(MmapFile& irExec, MmapFile& irCore)
 	else
 		rc = InitLinkMap_32 (irExec, irCore);
 
-	return rc;
+	return init_heap_managers();
 }
 
 static bool VerifyELFHeader(Elf64_Ehdr* elfhdr )

--- a/src/core_pe_x86.cpp
+++ b/src/core_pe_x86.cpp
@@ -688,10 +688,9 @@ extern bool g_dbgheap;
 
 bool InitCoreAnalyzer(MmapFile& irExec, MmapFile& irCore)
 {
-	register_heap_managers();
 	bool rc = BuildSegments(irCore) /*&& test_segments(true)*/;
 
-	return rc;
+	return init_heap_managers();
 }
 
 static struct ca_segment*

--- a/src/heap.cpp
+++ b/src/heap.cpp
@@ -16,7 +16,7 @@ CoreAnalyzerHeapInterface* gCAHeap;
 
 std::map<std::string, CoreAnalyzerHeapInterface*> gCoreAnalyzerHeaps;
 
-static std::vector<void(*)()> gHeapInitFuncs = {
+static std::vector<void(*)()> gHeapRegistrationFuncs = {
 	#ifdef WIN32
     register_mscrt_malloc,
 	#else
@@ -31,7 +31,7 @@ bool init_heap_managers() {
     gCoreAnalyzerHeaps.clear();
     gCAHeap = nullptr;
 
-    for (auto f: gHeapInitFuncs)
+    for (auto f: gHeapRegistrationFuncs)
         f();
 
     if (gCAHeap) {

--- a/src/heap.cpp
+++ b/src/heap.cpp
@@ -18,12 +18,12 @@ std::map<std::string, CoreAnalyzerHeapInterface*> gCoreAnalyzerHeaps;
 
 static std::vector<void(*)()> gHeapInitFuncs = {
 	#ifdef WIN32
-    _init_mscrt_malloc,
+    register_mscrt_malloc,
 	#else
-    _init_pt_malloc_2_27,
-    _init_pt_malloc_2_31,
-    _init_pt_malloc_2_35,
-    //_init_tc_malloc,
+    register_pt_malloc_2_27,
+    register_pt_malloc_2_31,
+    register_pt_malloc_2_35,
+    //register_tc_malloc,
     #endif
 };
 

--- a/src/heap.cpp
+++ b/src/heap.cpp
@@ -20,7 +20,7 @@ static std::vector<void(*)()> gHeapInitFuncs = {
 	#ifdef WIN32
     _init_mscrt_malloc,
 	#else
-    _init_pt_malloc,
+    _init_pt_malloc_2_31,
     _init_pt_malloc_2_35,
     //_init_tc_malloc,
     #endif
@@ -37,6 +37,7 @@ bool init_heap_managers() {
         CA_HEAP->init_heap();
         return true;
     }
+	CA_PRINT("failed to parse heap data\n");
     return false;
 }
 
@@ -147,6 +148,11 @@ char ca_help_msg[] = "Commands of core_analyzer " CA_VERSION_STRING "\n"
  */
 bool heap_command_impl(const char* args)
 {
+	if (!CA_HEAP) {
+		CA_PRINT("CA is not initialized.\n");
+		return false;
+	}
+
 	bool rc = true;
 
 	address_t addr = 0;
@@ -339,6 +345,11 @@ bool heap_command_impl(const char* args)
  */
 bool ref_command_impl(const char* args)
 {
+	if (!CA_HEAP) {
+		CA_PRINT("CA is not initialized.\n");
+		return false;
+	}
+
 	int rc;
 	bool threadref = false;
 	address_t addr = 0;
@@ -561,6 +572,11 @@ bool segment_command_impl(const char* args)
  */
 bool pattern_command_impl(const char* args)
 {
+	if (!CA_HEAP) {
+		CA_PRINT("CA is not initialized.\n");
+		return false;
+	}
+
 	address_t lo = 0, hi = 0;
 	// Parse user input options
 	// argument is in the form of <start> <end>
@@ -1312,7 +1328,6 @@ leak_check_out:
  */
 void display_mem_histogram(const char* prefix)
 {
-
 	if (!g_mem_hist.num_buckets || !g_mem_hist.bucket_sizes
 		|| !g_mem_hist.inuse_cnt || !g_mem_hist.inuse_bytes
 		|| !g_mem_hist.free_cnt || !g_mem_hist.free_bytes)

--- a/src/heap.cpp
+++ b/src/heap.cpp
@@ -14,6 +14,14 @@
 
 CoreAnalyzerHeapInterface* gCAHeap;
 
+#define ENSURE_CA_HEAP()							\
+	do {											\
+		if (!CA_HEAP) {								\
+			CA_PRINT("No heap manager is detedted or selected.\n");	\
+			return false;							\
+		}											\
+	} while (0)
+
 std::map<std::string, CoreAnalyzerHeapInterface*> gCoreAnalyzerHeaps;
 
 static std::vector<void(*)()> gHeapRegistrationFuncs = {
@@ -151,10 +159,7 @@ char ca_help_msg[] = "Commands of core_analyzer " CA_VERSION_STRING "\n"
  */
 bool heap_command_impl(const char* args)
 {
-	if (!CA_HEAP) {
-		CA_PRINT("CA is not initialized.\n");
-		return false;
-	}
+	ENSURE_CA_HEAP();
 
 	bool rc = true;
 
@@ -348,10 +353,7 @@ bool heap_command_impl(const char* args)
  */
 bool ref_command_impl(const char* args)
 {
-	if (!CA_HEAP) {
-		CA_PRINT("CA is not initialized.\n");
-		return false;
-	}
+	ENSURE_CA_HEAP();
 
 	int rc;
 	bool threadref = false;
@@ -575,10 +577,7 @@ bool segment_command_impl(const char* args)
  */
 bool pattern_command_impl(const char* args)
 {
-	if (!CA_HEAP) {
-		CA_PRINT("CA is not initialized.\n");
-		return false;
-	}
+	ENSURE_CA_HEAP();
 
 	address_t lo = 0, hi = 0;
 	// Parse user input options

--- a/src/heap.cpp
+++ b/src/heap.cpp
@@ -20,6 +20,7 @@ static std::vector<void(*)()> gHeapInitFuncs = {
 	#ifdef WIN32
     _init_mscrt_malloc,
 	#else
+    _init_pt_malloc_2_27,
     _init_pt_malloc_2_31,
     _init_pt_malloc_2_35,
     //_init_tc_malloc,
@@ -57,6 +58,8 @@ std::string get_supported_heaps() {
 		{
 			lSupportedHeaps += ", ";
 		}
+		if (itr.second == gCAHeap)
+			lSupportedHeaps += "(current)";
 		lSupportedHeaps += itr.first;
 		first_entry = false;
 	}

--- a/src/heap.h
+++ b/src/heap.h
@@ -82,6 +82,7 @@ extern void register_heap_manager(std::string, CoreAnalyzerHeapInterface*, bool)
 * Maybe we don't need to explicitly expose them. We may scape these functions at compile time
 * the same way gdb commands initializers are collected.
 */
+extern void _init_pt_malloc_2_27();
 extern void _init_pt_malloc_2_31();
 extern void _init_pt_malloc_2_35();
 extern void _init_tc_malloc();

--- a/src/heap.h
+++ b/src/heap.h
@@ -82,11 +82,11 @@ extern void register_heap_manager(std::string, CoreAnalyzerHeapInterface*, bool)
 * Maybe we don't need to explicitly expose them. We may scape these functions at compile time
 * the same way gdb commands initializers are collected.
 */
-extern void _init_pt_malloc_2_27();
-extern void _init_pt_malloc_2_31();
-extern void _init_pt_malloc_2_35();
-extern void _init_tc_malloc();
-extern void _init_mscrt_malloc();
+extern void register_pt_malloc_2_27();
+extern void register_pt_malloc_2_31();
+extern void register_pt_malloc_2_35();
+extern void register_tc_malloc();
+extern void register_mscrt_malloc();
 
 extern std::string get_supported_heaps();
 

--- a/src/heap.h
+++ b/src/heap.h
@@ -64,12 +64,29 @@ extern std::map<std::string, CoreAnalyzerHeapInterface*> gCoreAnalyzerHeaps;
 
 extern CoreAnalyzerHeapInterface* gCAHeap;
 #define CA_HEAP gCAHeap
-extern void register_heap_managers();
 
-extern CoreAnalyzerHeapInterface* get_pt_malloc_heap_manager();
-extern CoreAnalyzerHeapInterface* get_pt_malloc_2_35_heap_manager();
-extern CoreAnalyzerHeapInterface* get_tc_malloc_heap_manager();
-extern CoreAnalyzerHeapInterface* get_mscrt_malloc_heap_manager();
+/*
+* This function is called at bootstrap or when target is changed
+* and after target memory layout is scanned.
+*/
+extern bool init_heap_managers();
+
+/*
+* Individual heap manager calls this function in its init function
+* to declare its name, heap interface, and whether it detects its heap data in the target.
+*/
+extern void register_heap_manager(std::string, CoreAnalyzerHeapInterface*, bool);
+
+/*
+* Each heap manager implements an init function
+* Maybe we don't need to explicitly expose them. We may scape these functions at compile time
+* the same way gdb commands initializers are collected.
+*/
+extern void _init_pt_malloc();
+extern void _init_pt_malloc_2_35();
+extern void _init_tc_malloc();
+extern void _init_mscrt_malloc();
+
 extern std::string get_supported_heaps();
 
 extern struct inuse_block* build_inuse_heap_blocks(unsigned long*);

--- a/src/heap.h
+++ b/src/heap.h
@@ -82,7 +82,7 @@ extern void register_heap_manager(std::string, CoreAnalyzerHeapInterface*, bool)
 * Maybe we don't need to explicitly expose them. We may scape these functions at compile time
 * the same way gdb commands initializers are collected.
 */
-extern void _init_pt_malloc();
+extern void _init_pt_malloc_2_31();
 extern void _init_pt_malloc_2_35();
 extern void _init_tc_malloc();
 extern void _init_mscrt_malloc();

--- a/src/heap_mscrt.cpp
+++ b/src/heap_mscrt.cpp
@@ -237,8 +237,8 @@ CoreAnalyzerHeapInterface sMscrtMallocHeap = {
    get_biggest_blocks,
    walk_inuse_blocks,
 };
-CoreAnalyzerHeapInterface* get_mscrt_malloc_heap_manager() {
-	return &sMscrtMallocHeap;
+void _init_mscrt_malloc() {
+    register_heap_manager(HeapManagerMscrtMalloc, &sMscrtMallocHeap, true);
 }
 /////////////////////////////////////////////////////
 // Implementation of heap walk

--- a/src/heap_mscrt.cpp
+++ b/src/heap_mscrt.cpp
@@ -237,7 +237,7 @@ CoreAnalyzerHeapInterface sMscrtMallocHeap = {
    get_biggest_blocks,
    walk_inuse_blocks,
 };
-void _init_mscrt_malloc() {
+void register_mscrt_malloc() {
     register_heap_manager(HeapManagerMscrtMalloc, &sMscrtMallocHeap, true);
 }
 /////////////////////////////////////////////////////

--- a/src/heap_ptmalloc.cpp
+++ b/src/heap_ptmalloc.cpp
@@ -665,8 +665,8 @@ static CoreAnalyzerHeapInterface sPtMallHeapManager = {
    walk_inuse_blocks,
 };
 
-CoreAnalyzerHeapInterface* get_pt_malloc_heap_manager() {
-	return &sPtMallHeapManager;
+void _init_pt_malloc() {
+    return register_heap_manager("pt", &sPtMallHeapManager, true);
 }
 /***************************************************************************
 * Ptmalloc Helper Functions

--- a/src/heap_ptmalloc.cpp
+++ b/src/heap_ptmalloc.cpp
@@ -665,7 +665,7 @@ static CoreAnalyzerHeapInterface sPtMallHeapManager = {
    walk_inuse_blocks,
 };
 
-void _init_pt_malloc() {
+void register_pt_malloc() {
     return register_heap_manager("pt", &sPtMallHeapManager, true);
 }
 /***************************************************************************

--- a/src/heap_ptmalloc.h
+++ b/src/heap_ptmalloc.h
@@ -417,24 +417,6 @@ struct malloc_state_GLIBC_2_22 {
 #define HEAP_MAX_SIZE_GLIBC_2_22    HEAP_MAX_SIZE_GLIBC_2_5
 #define MAX_FAST_SIZE_GLIBC_2_22    MAX_FAST_SIZE_GLIBC_2_12
 
-
-/************************************************************************
-**  GNU C Library version 2.26 -
-**    Per-thread cache is added
-************************************************************************/
-# define TCACHE_MAX_BINS		64
-
-typedef struct tcache_entry
-{
-  struct tcache_entry *next;
-} tcache_entry;
-
-typedef struct tcache_perthread_struct
-{
-  uint16_t counts[TCACHE_MAX_BINS];
-  tcache_entry *entries[TCACHE_MAX_BINS];
-} tcache_perthread_struct;
-
 #define chunk2mem(p)   ((void*)((char*)(p) + 2*SIZE_SZ))
 #define mem2chunk(mem) ((mchunkptr)((char*)(mem) - 2*SIZE_SZ))
 

--- a/src/heap_ptmalloc_2_27.cpp
+++ b/src/heap_ptmalloc_2_27.cpp
@@ -19,16 +19,18 @@
 /*
 *   Per-thread cache is added since GNU C Library version 2.26
 */
+
 # define TCACHE_MAX_BINS		64
 
 typedef struct tcache_entry
 {
   struct tcache_entry *next;
+  struct tcache_perthread_struct *key;
 } tcache_entry;
 
 typedef struct tcache_perthread_struct
 {
-  uint16_t counts[TCACHE_MAX_BINS];
+  char counts[TCACHE_MAX_BINS];
   tcache_entry *entries[TCACHE_MAX_BINS];
 } tcache_perthread_struct;
 
@@ -679,13 +681,13 @@ static CoreAnalyzerHeapInterface sPtMallHeapManager = {
    walk_inuse_blocks,
 };
 
-void _init_pt_malloc_2_31() {
+void _init_pt_malloc_2_27() {
     bool my_heap = false;
     if (ca_glibc_version(&glibc_ver_major, &glibc_ver_minor)) {
-        if (glibc_ver_major == 2 && glibc_ver_minor >= 28 && glibc_ver_minor <= 31)
+        if (glibc_ver_major == 2 && glibc_ver_minor <= 27)
             my_heap = true;
     }
-    return register_heap_manager("pt 2.28-2.31", &sPtMallHeapManager, my_heap);
+    return register_heap_manager("pt 2.27", &sPtMallHeapManager, my_heap);
 }
 /***************************************************************************
 * Ptmalloc Helper Functions

--- a/src/heap_ptmalloc_2_31.cpp
+++ b/src/heap_ptmalloc_2_31.cpp
@@ -5,6 +5,7 @@
  *      Author: myan
  */
 #include <assert.h>
+#include <gnu/libc-version.h>
 
 #include "x_dep.h"
 #include "segment.h"
@@ -219,6 +220,7 @@ static bool get_field_value(struct value *, const char *, size_t *, bool);
 
 static bool memcpy_field_value(struct value *, const char *, char *, size_t);
 
+static bool get_glibc_version(int *major, int *minor);
 /***************************************************************************
 * Exposed functions
 ***************************************************************************/
@@ -679,9 +681,9 @@ static CoreAnalyzerHeapInterface sPtMallHeapManager = {
    walk_inuse_blocks,
 };
 
-void _init_pt_malloc_2_31() {
+void register_pt_malloc_2_31() {
     bool my_heap = false;
-    if (ca_glibc_version(&glibc_ver_major, &glibc_ver_minor)) {
+    if (get_glibc_version(&glibc_ver_major, &glibc_ver_minor)) {
         if (glibc_ver_major == 2 && glibc_ver_minor >= 28 && glibc_ver_minor <= 31)
             my_heap = true;
     }
@@ -690,6 +692,49 @@ void _init_pt_malloc_2_31() {
 /***************************************************************************
 * Ptmalloc Helper Functions
 ***************************************************************************/
+
+/*
+ * Get the glibc version of the debugee
+ */
+static bool get_glibc_version(int *major, int *minor)
+{
+	if (!major || !minor)
+		return false;
+
+	const size_t bufsz = 64;
+	char buf[bufsz];
+
+	memset(buf, 0, bufsz);
+	if (!get_gv_value("__libc_version", buf, bufsz)) {
+		CA_PRINT("Cannot get the \"__libc_version\" from the debugee, read it from the host machine. This might not be accurate.\n");
+		const char* version = gnu_get_libc_version();
+		int len = strlen(version);
+		if (len >= bufsz)
+			return false;
+
+		strncpy(buf, version, len+1);
+	}
+
+	int len = strlen(buf);
+	for (int i=0; i<len; i++)
+	{
+		if (buf[i] == '.')
+		{
+			buf[i] = '\0';
+			*major = atoi(&buf[0]);
+			*minor = atoi(&buf[i+1]);
+			if (*major != 2)
+			{
+				CA_PRINT("This version of glibc %d.%d is not tested, please contact the owner\n",
+						*major, *minor);
+				return false;
+			}
+			return true;
+		}
+	}
+
+	return false;
+}
 
 /*
  * compare two ca_heaps by their starting address

--- a/src/heap_ptmalloc_2_35.cpp
+++ b/src/heap_ptmalloc_2_35.cpp
@@ -2123,8 +2123,8 @@ type_field_name2no(struct type *type, const char *field_name)
 
 	type = check_typedef (type);
 
-	for (n = 0; n < type->num_fields(); n++) {
-		const char* name = type->field(n).name();
+	for (n = 0; n < ca_num_fields(type); n++) {
+		const char* name = ca_field_name(type, n);
 		if (name && strcmp (field_name, name) == 0)
 			return n;
 	}

--- a/src/heap_ptmalloc_2_35.cpp
+++ b/src/heap_ptmalloc_2_35.cpp
@@ -670,8 +670,8 @@ static CoreAnalyzerHeapInterface sPtMallHeapManager = {
    walk_inuse_blocks,
 };
 
-CoreAnalyzerHeapInterface* get_pt_malloc_2_35_heap_manager() {
-	return &sPtMallHeapManager;
+void _init_pt_malloc_2_35() {
+    return register_heap_manager("pt 2.35", &sPtMallHeapManager, true);
 }
 /***************************************************************************
 * Ptmalloc Helper Functions

--- a/src/heap_ptmalloc_2_35.cpp
+++ b/src/heap_ptmalloc_2_35.cpp
@@ -20,6 +20,22 @@
 ***************************************************************************/
 
 /*
+*   Per-thread cache is added since GNU C Library version 2.26
+*/
+# define TCACHE_MAX_BINS		64
+
+typedef struct tcache_entry
+{
+  struct tcache_entry *next;
+} tcache_entry;
+
+typedef struct tcache_perthread_struct
+{
+  uint16_t counts[TCACHE_MAX_BINS];
+  tcache_entry *entries[TCACHE_MAX_BINS];
+} tcache_perthread_struct;
+
+/*
  * Uniformed data structure to hide the differences across ptmalloc versions;
  * Only useful members are included
  */
@@ -671,10 +687,10 @@ static CoreAnalyzerHeapInterface sPtMallHeapManager = {
 void _init_pt_malloc_2_35() {
     bool my_heap = false;
     if (ca_glibc_version(&glibc_ver_major, &glibc_ver_minor)) {
-        if (glibc_ver_major == 2 && glibc_ver_minor >= 35)
+        if (glibc_ver_major == 2 && glibc_ver_minor >= 32 && glibc_ver_minor <= 35)
             my_heap = true;
     }
-    return register_heap_manager("pt 2.35", &sPtMallHeapManager, my_heap);
+    return register_heap_manager("pt 2.32-2.35", &sPtMallHeapManager, my_heap);
 }
 /***************************************************************************
 * Ptmalloc Helper Functions

--- a/src/heap_ptmalloc_2_35.cpp
+++ b/src/heap_ptmalloc_2_35.cpp
@@ -5,6 +5,7 @@
  *      Author: myan
  */
 #include <assert.h>
+#include <gnu/libc-version.h>
 
 #include "segment.h"
 #include "heap_ptmalloc.h"
@@ -223,6 +224,7 @@ static bool get_field_value(struct value *, const char *, size_t *, bool);
 
 static bool memcpy_field_value(struct value *, const char *, char *, size_t);
 
+static bool get_glibc_version(int *major, int *minor);
 /***************************************************************************
 * Exposed functions
 ***************************************************************************/
@@ -684,9 +686,9 @@ static CoreAnalyzerHeapInterface sPtMallHeapManager = {
    walk_inuse_blocks,
 };
 
-void _init_pt_malloc_2_35() {
+void register_pt_malloc_2_35() {
     bool my_heap = false;
-    if (ca_glibc_version(&glibc_ver_major, &glibc_ver_minor)) {
+    if (get_glibc_version(&glibc_ver_major, &glibc_ver_minor)) {
         if (glibc_ver_major == 2 && glibc_ver_minor >= 32 && glibc_ver_minor <= 35)
             my_heap = true;
     }
@@ -695,6 +697,49 @@ void _init_pt_malloc_2_35() {
 /***************************************************************************
 * Ptmalloc Helper Functions
 ***************************************************************************/
+
+/*
+ * Get the glibc version of the debugee
+ */
+static bool get_glibc_version(int *major, int *minor)
+{
+	if (!major || !minor)
+		return false;
+
+	const size_t bufsz = 64;
+	char buf[bufsz];
+
+	memset(buf, 0, bufsz);
+	if (!get_gv_value("__libc_version", buf, bufsz)) {
+		CA_PRINT("Cannot get the \"__libc_version\" from the debugee, read it from the host machine. This might not be accurate.\n");
+		const char* version = gnu_get_libc_version();
+		int len = strlen(version);
+		if (len >= bufsz)
+			return false;
+
+		strncpy(buf, version, len+1);
+	}
+
+	int len = strlen(buf);
+	for (int i=0; i<len; i++)
+	{
+		if (buf[i] == '.')
+		{
+			buf[i] = '\0';
+			*major = atoi(&buf[0]);
+			*minor = atoi(&buf[i+1]);
+			if (*major != 2)
+			{
+				CA_PRINT("This version of glibc %d.%d is not tested, please contact the owner\n",
+						*major, *minor);
+				return false;
+			}
+			return true;
+		}
+	}
+
+	return false;
+}
 
 /*
  * compare two ca_heaps by their starting address

--- a/src/heap_tcmalloc.cpp
+++ b/src/heap_tcmalloc.cpp
@@ -548,11 +548,9 @@ CoreAnalyzerHeapInterface sTcMallHeapManager = {
    walk_inuse_blocks,
 };
 
-CoreAnalyzerHeapInterface* get_tc_malloc_heap_manager()
-{
-	return &sTcMallHeapManager;
+void _init_tc_malloc() {
+    return register_heap_manager("tc", &sTcMallHeapManager, false);
 }
-
 /******************************************************************************
  * Helper Functions
  *****************************************************************************/

--- a/src/heap_tcmalloc.cpp
+++ b/src/heap_tcmalloc.cpp
@@ -548,7 +548,7 @@ CoreAnalyzerHeapInterface sTcMallHeapManager = {
    walk_inuse_blocks,
 };
 
-void _init_tc_malloc() {
+void register_tc_malloc() {
     return register_heap_manager("tc", &sTcMallHeapManager, false);
 }
 /******************************************************************************

--- a/src/x_dep.h
+++ b/src/x_dep.h
@@ -29,6 +29,10 @@ struct ca_debug_context
 extern bool update_memory_segments_and_heaps(void);
 
 extern bool inferior_memory_read (address_t addr, void* buffer, size_t sz);
+extern void ca_switch_to_thread(struct thread_info *info);
+extern int ca_num_fields(struct type *type);
+extern const char *ca_field_name(struct type *type, int i);
+extern bool ca_glibc_version(int *major, int *minor);
 
 extern void print_register_ref(const struct object_reference* ref);
 extern void print_stack_ref(const struct object_reference* ref);

--- a/src/x_dep.h
+++ b/src/x_dep.h
@@ -32,7 +32,7 @@ extern bool inferior_memory_read (address_t addr, void* buffer, size_t sz);
 extern void ca_switch_to_thread(struct thread_info *info);
 extern int ca_num_fields(struct type *type);
 extern const char *ca_field_name(struct type *type, int i);
-extern bool ca_glibc_version(int *major, int *minor);
+extern bool get_gv_value(const char *varname, char *buf, size_t bufsz);
 
 extern void print_register_ref(const struct object_reference* ref);
 extern void print_stack_ref(const struct object_reference* ref);

--- a/test/makefile
+++ b/test/makefile
@@ -7,7 +7,7 @@ LIBS = -lpthread
 
 TARGETS = mallocTest
 
-GDB    = /workspaces/core_analyzer/build/gdb-9.2/build/gdb/gdb --data-directory=/usr/share/gdb
+GDB    = /workspaces/core_analyzer/build/gdb-12.1/build/gdb/gdb --data-directory=/usr/share/gdb
 
 all: ${TARGETS}
 


### PR DESCRIPTION
## Change
This is one step closer to the gdb implementation with multiple heap managers coexist, which might be different type of heap managers or the same one with different versions. The initialization of heap managers is slightly changed so that it is started from the gdb instead of the individual heap manager implementation. I added a rudimentary auto detection of active heap manager in the target process.

## Test
Tests are run on Ubuntu 18.04 (glibc 2.27), 20.04 (glibc 2.31) and 22.04 (glibc 2.35), with gdb 9.2 and 12.1. All compilation and unit test passed except gdb 9.2 + Ubuntu 22.04 which doesn't compile due to gdb itself.

## Todo
tcmalloc is not included yet. We may also refactor ptmalloc implementation of various versions.
