### PR TITLE
add the 9.2 ut to the docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,10 @@ RUN ./build_gdb.sh
 WORKDIR test
 RUN make check
 RUN make check-tcmalloc
+WORKDIR /workspaces/core_analyzer/
+RUN ./build_gdb.sh 9.2
 
+WORKDIR test
+RUN make check
+RUN make check-tcmalloc
 

--- a/build_gdb.sh
+++ b/build_gdb.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # ==============================================================================================
 # FILENAME	:	build_gdb.sh
 # AUTHOR	:	Celthi
@@ -10,8 +12,16 @@
 # 4. build the gdb
 # ==============================================================================================
 
+set -e
+gdb_version="12.1"
+if [ "$#" -ne 1 ]
+then
+    echo "build gdb 12.1"
+else
+    gdb_version=$1
+fi
+
 PROJECT_FOLDER=$(pwd)
-gdb_version='12.1'
 echo "Current project folder is $PROJECT_FOLDER"
 echo "installing gdb $gdb_version..."
 build_folder=$PROJECT_FOLDER/build


### PR DESCRIPTION
This PR adds the gdb 9.2 into the docker file so the unit test will be run for gdb version 9.2