### PR TITLE
use ubuntu 22.04 as the dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,9 +8,9 @@ FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
     && apt install -y texinfo \
     && apt install -y libgmp-dev \
+    && apt install -y libdebuginfod-dev \
     && apt install -y build-essential \
     && apt install -y wget \
-    && apt install -y python-dev \
     && apt install -y python3-dev \
     && apt install -y dh-autoreconf 
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 		"dockerfile": "Dockerfile",
 		// Update 'VARIANT' to pick an Debian / Ubuntu OS version: debian-11, debian-10, debian-9, ubuntu-21.04, ubuntu-20.04, ubuntu-18.04
 		// Use Debian 11, Debian 9, Ubuntu 18.04 or Ubuntu 21.04 on local arm64/Apple Silicon
-		"args": { "VARIANT": "ubuntu-20.04" }
+		"args": { "VARIANT": "ubuntu-22.04" }
 	},
 	"runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
 
@@ -29,7 +29,6 @@
 	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {
-		"git": "latest",
-		"git-lfs": "latest"
+		"git": "latest"
 	}
 }


### PR DESCRIPTION
Ubuntu 22.04 has more features and we use build gdb with debuginfod.