### PR TITLE
add a logging while cannot init heap

### DIFF
--- a/src/heap.cpp
+++ b/src/heap.cpp
@@ -42,7 +42,10 @@ bool init_heap_managers() {
         f();
 
     if (gCAHeap) {
-        CA_HEAP->init_heap();
+        if (!CA_HEAP->init_heap()) {
+			CA_PRINT("failed to init heap\n");
+			return false;
+		}
         return true;
     }
 	CA_PRINT("failed to parse heap data\n");

--- a/src/heap_ptmalloc_2_31.cpp
+++ b/src/heap_ptmalloc_2_31.cpp
@@ -1596,19 +1596,6 @@ static bool build_heaps(void)
 		release_all_ca_arenas();
 		release_tcache_chunks();
 	}
-#if 0
-	// Support a subset of all glibc versions
-	if (glibc_ver_minor != 3
-		&& glibc_ver_minor != 4
-		&& glibc_ver_minor != 5
-		//&& glibc_ver_minor != 11
-		&& (glibc_ver_minor < 12 || glibc_ver_minor > 29))
-	{
-		CA_PRINT("The memory manager of glibc %d.%d is not supported in this release\n",
-				glibc_ver_major, glibc_ver_minor);
-		return false;
-	}
-#endif
 	main_arena_vaddr = get_var_addr_by_name("main_arena", true);
 	mparams_vaddr    = get_var_addr_by_name("mp_", true);
 	if (main_arena_vaddr == 0 || mparams_vaddr == 0)


### PR DESCRIPTION
If init heap failed, log a message.
Sometimes, we get "Failed to walk heap" error message and don't know why. This logging is one step to reveal the root cause.
