### PR TITLE
Fixes #76; incorrect initialization of std::set g_shared_objects

### DIFF
--- a/src/heap.cpp
+++ b/src/heap.cpp
@@ -408,7 +408,7 @@ bool segment_command_impl(char* args)
 {
 	struct ca_segment* segment;
 
-	if (args)
+	if (args && *args != '\0')
 	{
 		address_t addr = ca_eval_address (args);
 		segment = get_segment(addr, 0);

--- a/src/heap_ptmalloc_2_27.cpp
+++ b/src/heap_ptmalloc_2_27.cpp
@@ -822,7 +822,8 @@ static void add_ca_heap(struct ca_arena* arena, struct ca_heap* heap)
 	heap->mpNext = NULL;
 
 	// fixup segment type
-	if (heap->mSegment->m_type != ENUM_HEAP)
+	// TODO could heap share a segment with stack?
+	if (heap->mSegment->m_type == ENUM_UNKNOWN)
 		heap->mSegment->m_type = ENUM_HEAP;
 
 }

--- a/src/heap_ptmalloc_2_31.cpp
+++ b/src/heap_ptmalloc_2_31.cpp
@@ -821,7 +821,8 @@ static void add_ca_heap(struct ca_arena* arena, struct ca_heap* heap)
 	heap->mpNext = NULL;
 
 	// fixup segment type
-	if (heap->mSegment->m_type != ENUM_HEAP)
+	// TODO could heap share a segment with stack?
+	if (heap->mSegment->m_type == ENUM_UNKNOWN)
 		heap->mSegment->m_type = ENUM_HEAP;
 
 }

--- a/src/heap_ptmalloc_2_35.cpp
+++ b/src/heap_ptmalloc_2_35.cpp
@@ -826,7 +826,8 @@ static void add_ca_heap(struct ca_arena* arena, struct ca_heap* heap)
 	heap->mpNext = NULL;
 
 	// fixup segment type
-	if (heap->mSegment->m_type != ENUM_HEAP)
+	// TODO could heap share a segment with stack?
+	if (heap->mSegment->m_type == ENUM_UNKNOWN)
 		heap->mSegment->m_type = ENUM_HEAP;
 
 }

--- a/src/heap_tcmalloc.cpp
+++ b/src/heap_tcmalloc.cpp
@@ -1412,7 +1412,7 @@ parse_span(struct value *span)
 
 	segment = get_segment(my_span->start << g_config.kPageShift,
 	    my_span->length << g_config.kPageShift);
-	if (segment != NULL)
+	if (segment != NULL && segment->m_type == ENUM_UNKNOWN)
 		segment->m_type = ENUM_HEAP;
 
 	return true;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1286,7 +1286,7 @@ static bool shared_objects_internal(std::list<int>& threads, bool verbose)
 {
 	unsigned int i;
 	struct ca_segment* segment;
-	char* input_tid_map = NULL;
+	char* input_tid_map = nullptr;
 	int max_tid = 0;
 
 	// check whether the thread list contains valid thread IDs
@@ -1312,7 +1312,7 @@ static bool shared_objects_internal(std::list<int>& threads, bool verbose)
 		return false;
 	}
 	// convert the thread list into an array indexed by thread id
-	input_tid_map = (char*) malloc (max_tid + 1);
+	input_tid_map = new char [max_tid + 1];
 	if (!threads.empty())
 	{
 		memset(input_tid_map, 0, max_tid + 1);
@@ -1325,7 +1325,7 @@ static bool shared_objects_internal(std::list<int>& threads, bool verbose)
 			{
 				if (verbose)
 					CA_PRINT("Input thread id is out of range %d\n", tid);
-				free (input_tid_map);
+				delete[] input_tid_map;
 				return false;
 			}
 		}
@@ -1350,8 +1350,12 @@ static bool shared_objects_internal(std::list<int>& threads, bool verbose)
 		if (segment->m_type == ENUM_STACK && input_tid_map[segment->m_thread.tid])
 			find_shared_objects_one_thread (segment, false);
 	}
+
+#if 0
 	// Second search all other threads' registers/stacks,
 	// ignore all new shared objects, and append owner for previously found shared objects
+
+	// It is a bit confusing to include threads that are not selected
 	for (i=0; i<g_segment_count; i++)
 	{
 		if (user_request_break())
@@ -1365,9 +1369,10 @@ static bool shared_objects_internal(std::list<int>& threads, bool verbose)
 		if (segment->m_type == ENUM_STACK && !input_tid_map[segment->m_thread.tid])
 			find_shared_objects_one_thread (segment, true);
 	}
+#endif
 
 	// clean up
-	free(input_tid_map);
+	delete[] input_tid_map;
 
 	return true;
 }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -45,7 +45,7 @@ static unsigned int g_output_count = 0;
 
 static bool shared_object_comp_func(void *lhs, void *rhs);
 typedef std::set<struct shared_object*, decltype(&shared_object_comp_func)> SharedObjectSet;
-static  SharedObjectSet g_shared_objects;
+static  SharedObjectSet g_shared_objects(&shared_object_comp_func);
 
 /////////////////////////////////////////////////////
 // forward declarations.

--- a/test/mallocTest.cpp
+++ b/test/mallocTest.cpp
@@ -262,7 +262,7 @@ main(int argc, char** argv)
 	}
 	hidden_object = (uintptr_t)objlist.front();
 
-	bool flags[NUM_THREADS];
+	bool *flags = new bool [NUM_THREADS];
 	for (i = 0; i < NUM_THREADS; i++)
 		flags[i] = false;
 
@@ -290,6 +290,8 @@ main(int argc, char** argv)
 
 	// Test driver may break at this function for inspection or create a core dump
 	last_call();
+
+	delete[] flags;
 
 	return 0;
 }

--- a/test/verify.py
+++ b/test/verify.py
@@ -143,6 +143,8 @@ def check_heap_commands():
 def check_misc_commands():
 	print("[ca_test] Execute command 'shrobj'")
 	gdb.execute('shrobj')
+	print("[ca_test] Execute command 'segment'")
+	gdb.execute('segment')
 
 def run_tests():
 	# Retrieve global variables defined in mallocTest

--- a/test/verify.py
+++ b/test/verify.py
@@ -135,8 +135,14 @@ def check_ref():
 		% (refs[0].heap_addr, refs[0].heap_size, obj_addr))
 
 def check_heap_commands():
+	print("[ca_test] Execute command 'heap /u regions'")
 	gdb.execute('heap /u regions')
+	print("[ca_test] Execute command 'heap /tb 3'")
 	gdb.execute('heap /tb 3')
+
+def check_misc_commands():
+	print("[ca_test] Execute command 'shrobj'")
+	gdb.execute('shrobj')
 
 def run_tests():
 	# Retrieve global variables defined in mallocTest
@@ -152,6 +158,7 @@ def run_tests():
 	check_cplusplus_object("Derived", object_count)
 	check_ref()
 	check_heap_commands()
+	check_misc_commands()
 
 #
 # Fun starts here


### PR DESCRIPTION
We should initialize the std::set with the custom comparator as the input argument.