### PR TITLE
fix ptmalloc 2.34 failure due to dynamic arena's struct heap_info

### DIFF
--- a/test/DockerfileTest_redhat
+++ b/test/DockerfileTest_redhat
@@ -5,9 +5,6 @@
 # Dockerfile to test core analyzer against ptmalloc/tcmalloc/jemalloc
 # ==============================================================================================
 
-# redhat/ubi9
-#     ptmalloc(2.34) fails because of dynamic arena error.
-
 #ARG VARIANT="fedora:37"
 #ARG VARIANT="fedora:36"
 #ARG VARIANT="redhat/ubi9"

--- a/test/readme.md
+++ b/test/readme.md
@@ -26,3 +26,9 @@ It is more convinient to run the regression test in a container. The following c
 ```
 docker build -t ca_test -f test/DockerfileTest_...  .
 ```
+
+### Regression Test
+The full test suite is run by this script.
+```
+./test/regression.sh
+```

--- a/test/regression.sh
+++ b/test/regression.sh
@@ -14,6 +14,7 @@ set -ex
 #   2.37      ubuntu:23.04, opensuse/tumbleweed
 #   2.36      debian:bookworm, fedora:37
 #   2.35      ubuntu:22.04, fedora:36
+#   2.34      redhat/ubi9
 #   2.31      debian:bullseye, ubuntu:20.04, opensuse/leap
 #   2.28      redhat/ubi8
 #   2.27      ubuntu:18.04
@@ -38,6 +39,9 @@ docker build --build-arg VARIANT="debian:bullseye" -t ca_test -q -f test/Dockerf
 
 docker system prune -af > /dev/null
 docker build --build-arg VARIANT="debian:bookworm" -t ca_test -q -f test/DockerfileTest_ubuntu .
+
+docker system prune -af > /dev/null
+docker build --build-arg VARIANT="redhat/ubi9" -t ca_test -q -f test/DockerfileTest_redhat .
 
 docker system prune -af > /dev/null
 docker build --build-arg VARIANT="redhat/ubi8" -t ca_test -q -f test/DockerfileTest_redhat .


### PR DESCRIPTION
The current ptmalloc parser uses a predefined struct for dynamic arena's header `struct _heap_info`. This structure is not stable over various versions. The fix is to read the type info at runtime instead of the fixed definition.