### PR TITLE
Fix #103; update refs to g_arenas[i] after realloc

### DIFF
--- a/gdbplus/gdb-7.11.1/gdb/heap_ptmalloc.c
+++ b/gdbplus/gdb-7.11.1/gdb/heap_ptmalloc.c
@@ -793,6 +793,8 @@ static void add_ca_heap(struct ca_arena* arena, struct ca_heap* heap)
 static struct ca_arena* alloc_ca_arena(void)
 {
 	struct ca_arena* arena;
+    int i;
+    struct ca_heap* heap;
 
 	if (g_arena_cnt >= g_arena_buf_sz)
 	{
@@ -801,6 +803,13 @@ static struct ca_arena* alloc_ca_arena(void)
 		else
 			g_arena_buf_sz *= 2;
 		g_arenas = (struct ca_arena*) realloc(g_arenas, sizeof(struct ca_arena)*g_arena_buf_sz);
+        for (i = 0; i < g_arena_cnt; ++i)
+        {
+            for (heap = g_arenas[i].mpHeap; heap != NULL; heap = heap->mpNext)
+            {
+                heap->mArena = &g_arenas[i];
+            }
+        }
 	}
 	arena = &g_arenas[g_arena_cnt++];
 	memset(arena, 0, sizeof(struct ca_arena));

--- a/gdbplus/gdb-8.1/gdb/heap_ptmalloc.c
+++ b/gdbplus/gdb-8.1/gdb/heap_ptmalloc.c
@@ -793,6 +793,8 @@ static void add_ca_heap(struct ca_arena* arena, struct ca_heap* heap)
 static struct ca_arena* alloc_ca_arena(void)
 {
 	struct ca_arena* arena;
+    int i;
+    struct ca_heap* heap;
 
 	if (g_arena_cnt >= g_arena_buf_sz)
 	{
@@ -801,6 +803,13 @@ static struct ca_arena* alloc_ca_arena(void)
 		else
 			g_arena_buf_sz *= 2;
 		g_arenas = (struct ca_arena*) realloc(g_arenas, sizeof(struct ca_arena)*g_arena_buf_sz);
+        for (i = 0; i < g_arena_cnt; ++i)
+        {
+            for (heap = g_arenas[i].mpHeap; heap != NULL; heap = heap->mpNext)
+            {
+                heap->mArena = &g_arenas[i];
+            }
+        }
 	}
 	arena = &g_arenas[g_arena_cnt++];
 	memset(arena, 0, sizeof(struct ca_arena));

--- a/src/heap_ptmalloc_2_27.cpp
+++ b/src/heap_ptmalloc_2_27.cpp
@@ -827,6 +827,8 @@ static void add_ca_heap(struct ca_arena* arena, struct ca_heap* heap)
 static struct ca_arena* alloc_ca_arena(void)
 {
 	struct ca_arena* arena;
+    int i;
+    struct ca_heap* heap;
 
 	if (g_arena_cnt >= g_arena_buf_sz)
 	{
@@ -835,6 +837,13 @@ static struct ca_arena* alloc_ca_arena(void)
 		else
 			g_arena_buf_sz *= 2;
 		g_arenas = (struct ca_arena*) realloc(g_arenas, sizeof(struct ca_arena)*g_arena_buf_sz);
+        for (i = 0; i < g_arena_cnt; ++i)
+        {
+            for (heap = g_arenas[i].mpHeap; heap != NULL; heap = heap->mpNext)
+            {
+                heap->mArena = &g_arenas[i];
+            }
+        }
 	}
 	arena = &g_arenas[g_arena_cnt++];
 	memset(arena, 0, sizeof(struct ca_arena));

--- a/src/heap_ptmalloc_2_31.cpp
+++ b/src/heap_ptmalloc_2_31.cpp
@@ -826,6 +826,8 @@ static void add_ca_heap(struct ca_arena* arena, struct ca_heap* heap)
 static struct ca_arena* alloc_ca_arena(void)
 {
 	struct ca_arena* arena;
+    int i;
+    struct ca_heap* heap;
 
 	if (g_arena_cnt >= g_arena_buf_sz)
 	{
@@ -834,6 +836,13 @@ static struct ca_arena* alloc_ca_arena(void)
 		else
 			g_arena_buf_sz *= 2;
 		g_arenas = (struct ca_arena*) realloc(g_arenas, sizeof(struct ca_arena)*g_arena_buf_sz);
+        for (i = 0; i < g_arena_cnt; ++i)
+        {
+            for (heap = g_arenas[i].mpHeap; heap != NULL; heap = heap->mpNext)
+            {
+                heap->mArena = &g_arenas[i];
+            }
+        }
 	}
 	arena = &g_arenas[g_arena_cnt++];
 	memset(arena, 0, sizeof(struct ca_arena));

--- a/src/heap_ptmalloc_2_35.cpp
+++ b/src/heap_ptmalloc_2_35.cpp
@@ -831,6 +831,8 @@ static void add_ca_heap(struct ca_arena* arena, struct ca_heap* heap)
 static struct ca_arena* alloc_ca_arena(void)
 {
 	struct ca_arena* arena;
+    int i;
+    struct ca_heap* heap;
 
 	if (g_arena_cnt >= g_arena_buf_sz)
 	{
@@ -839,6 +841,13 @@ static struct ca_arena* alloc_ca_arena(void)
 		else
 			g_arena_buf_sz *= 2;
 		g_arenas = (struct ca_arena*) realloc(g_arenas, sizeof(struct ca_arena)*g_arena_buf_sz);
+        for (i = 0; i < g_arena_cnt; ++i)
+        {
+            for (heap = g_arenas[i].mpHeap; heap != NULL; heap = heap->mpNext)
+            {
+                heap->mArena = &g_arenas[i];
+            }
+        }
 	}
 	arena = &g_arenas[g_arena_cnt++];
 	memset(arena, 0, sizeof(struct ca_arena));


### PR DESCRIPTION
Fix #103; apply to all functions named as `alloc_ca_arena`.

Tested with core_analyzer + gdb 12.1.